### PR TITLE
finished switch to bearer auth

### DIFF
--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -11,8 +11,7 @@ export interface AuthRequest extends Request {
 }
 
 export const authenticateToken = (req: AuthRequest, res: Response, next: NextFunction) => {
-    // Read the JWT from the httpOnly cookie set on login
-    const token = req.cookies?.jwt;
+    const token = req.header("Authorization")?.replace("Bearer ", "")
 
     if (!token) {
         return res.sendStatus(StatusCodes.UNAUTHORIZED);

--- a/backend/src/routes/authRoutes.ts
+++ b/backend/src/routes/authRoutes.ts
@@ -44,9 +44,12 @@ router.post("/login",
         const { email, password } = req.body;
 
         const authService = new AuthService(unit);
-        const user = await authService.login(res, email, password); // Pass res and expect user object
+        const { user, token } = await authService.login(res, email, password); // Pass res and expect user object
         unit.complete(true);
-        return res.status(StatusCodes.OK).json(user); // Return user object, token is set as cookie
+        return res.status(StatusCodes.OK).json({
+            user: user,
+            token: token
+        });
     } catch (error: any) {
         unit.complete(false);
         if (error.message.includes("Invalid credentials")) {

--- a/backend/src/service/authService.ts
+++ b/backend/src/service/authService.ts
@@ -32,7 +32,7 @@ export class AuthService {
         return userWithoutPassword;
     }
 
-    public async login(res: Response, email: string, password: string): Promise<Omit<User, "password">> {
+    public async login(res: Response, email: string, password: string) {
         const user = this.userRepository.findByEmail(email);
         if (!user) {
             throw new Error("Invalid credentials");
@@ -43,10 +43,13 @@ export class AuthService {
             throw new Error("Invalid credentials");
         }
 
-        generateJWT(res, user.id.toString()); // Assuming user.id is a number, convert to string for jwtUtils
+        const token = generateJWT(user.id.toString());
         
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { password: _, ...userWithoutPassword } = user;
-        return userWithoutPassword;
+        return {
+            user: userWithoutPassword,
+            token
+        }
     }
 }

--- a/backend/src/utils/jwtUtils.ts
+++ b/backend/src/utils/jwtUtils.ts
@@ -1,33 +1,11 @@
-import { Response } from "express";
-import jwt from "jsonwebtoken";import { parseDurationToMilliseconds } from "../utils";
+import jwt from "jsonwebtoken";
 
 export const JWT_SECRET = process.env.JWT_SECRET || "secretkey";
 export const JWT_EXPIRY = process.env.JWT_EXPIRY || "30m";
 
-const generateJWT = (res: Response, userId: string) => {
-    // @ts-ignore
-    const token = jwt.sign({ userId }, JWT_SECRET, { expiresIn: JWT_EXPIRY });
-
-    // Use shared utility to parse duration, defaulting to 30 minutes if parsing fails
-    const maxAgeMilliseconds = parseDurationToMilliseconds(JWT_EXPIRY, 30 * 60 * 1000);
-
-    res.cookie("jwt", token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        maxAge: maxAgeMilliseconds,
-        path: "/",
-    });
+const generateJWT = (userId: string) => {
+    //@ts-ignore
+    return jwt.sign({userId}, JWT_SECRET, {expiresIn: JWT_EXPIRY});
 };
 
-const clearJWT = (res: Response) => {
-    res.cookie("jwt", "", {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        expires: new Date(0),
-        path: "/",
-    });
-};
-
-export { generateJWT, clearJWT };
+export { generateJWT };


### PR DESCRIPTION
closes #40 

This pull request refactors the authentication flow to move away from using httpOnly cookies for JWT storage and instead returns the JWT directly in the response. The changes improve clarity and flexibility in how tokens are handled on the frontend and backend, and simplify the JWT utility code.

Authentication flow changes:

* The `login` endpoint now returns both the user object and the JWT token in the response body, rather than setting the token as a cookie. (`backend/src/routes/authRoutes.ts`, [backend/src/routes/authRoutes.tsL47-R52](diffhunk://#diff-31d95f0f49a871423e3d52ba6aa947c7600e011b05de4f348a68c6ede79752f6L47-R52))
* The `AuthService.login` method was updated to return an object containing both the user (without password) and the JWT token, instead of just the user. (`backend/src/service/authService.ts`, [[1]](diffhunk://#diff-b01385b77fe2874c3549f3954d140704f5e9dc4e9a8e9b964caa5c0de3d4b5d3L35-R35) [[2]](diffhunk://#diff-b01385b77fe2874c3549f3954d140704f5e9dc4e9a8e9b964caa5c0de3d4b5d3L46-R53)

JWT handling simplification:

* The `generateJWT` function no longer sets cookies; it simply generates and returns a JWT string. Cookie-related code was removed. (`backend/src/utils/jwtUtils.ts`, [backend/src/utils/jwtUtils.tsL1-R11](diffhunk://#diff-e3d34acb0b5907620ea39ca121dfafd218d3d3b5bd63037aafae7a51b32470fcL1-R11))
* The `authenticateToken` middleware now reads the JWT from the `Authorization` header (Bearer token) instead of from cookies. (`backend/src/middleware/authMiddleware.ts`, [backend/src/middleware/authMiddleware.tsL14-R14](diffhunk://#diff-9b7498e6c2c91ae8a216adc882f90bf583afa57190c4ffe6edebb2ea0e0b82b0L14-R14))

These changes collectively make the authentication system more straightforward and compatible with token-based authentication best practices.