### PR TITLE
Add Recipes to favorites

### DIFF
--- a/backend/src/repository/favoriteRepository.ts
+++ b/backend/src/repository/favoriteRepository.ts
@@ -1,0 +1,36 @@
+import { Unit } from "../db/unit";
+import { FavoriteFood } from "../types";
+
+export class FavoriteRepository {
+    private unit: Unit;
+
+    constructor(unit: Unit) {
+        this.unit = unit;
+    }
+
+    public findByUserId(userId: number): FavoriteFood[] {
+        const stmt = this.unit.prepare<FavoriteFood>(
+            "SELECT * FROM FavoriteFood WHERE userId = :userId", 
+            { userId }
+        );
+        return stmt.all();
+    }
+
+    public create(userId: number, recipeId: number): FavoriteFood {
+        const stmt = this.unit.prepare(
+            "INSERT INTO FavoriteFood (userId, recipeId) VALUES (:userId, :recipeId) ON CONFLICT DO NOTHING",
+            { userId, recipeId }
+        );
+        stmt.run();
+        return { userId, recipeId };
+    }
+
+    public delete(userId: number, recipeId: number): boolean {
+        const stmt = this.unit.prepare(
+            "DELETE FROM FavoriteFood WHERE userId = :userId AND recipeId = :recipeId", 
+            { userId, recipeId }
+        );
+        const result = stmt.run();
+        return result.changes > 0;
+    }
+}

--- a/backend/src/routes/favoriteRoutes.ts
+++ b/backend/src/routes/favoriteRoutes.ts
@@ -6,6 +6,8 @@ import {validateRequest} from "../middleware/validationMiddleware";
 import { Unit } from "../db/unit";
 import { FavoriteService } from "../services/favoriteService";
 
+import { RecipeService } from "../services/recipeService";
+
 const router = Router();
 
 router.get('/', authenticateToken, (req: AuthRequest, res) => {
@@ -27,24 +29,27 @@ router.post('/',
     authenticateToken,
     body('recipeId').notEmpty().withMessage('recipeId is required').isInt().withMessage('recipeId must be an integer').toInt(),
     validateRequest,
-    (req: AuthRequest, res) => {
+    async (req: AuthRequest, res) => {
+        const userId = parseInt(req.user!.userId as unknown as string, 10);
+        const { recipeId } = req.body;
+
+        // Ensure the recipe exists in the local cache to satisfy the foreign key constraint
+        const recipeService = new RecipeService();
+        const recipe = await recipeService.getRecipeById(recipeId, req.ip);
+        if (!recipe) {
+            return res.status(StatusCodes.NOT_FOUND).json({ message: "Recipe not found." });
+        }
+
         const unit = new Unit(false);
         try {
             const favoriteService = new FavoriteService(unit);
-            const userId = parseInt(req.user!.userId as unknown as string, 10);
-            const { recipeId } = req.body;
-            
             const newFavorite = favoriteService.addFavorite(userId, recipeId);
             unit.complete(true);
             res.status(StatusCodes.CREATED).json(newFavorite);
         } catch (error: any) {
             unit.complete(false);
-            if (error.message && error.message.includes('FOREIGN KEY constraint failed')) {
-                res.status(StatusCodes.BAD_REQUEST).json({ message: "Recipe not found in local database." });
-            } else {
-                console.error("Add favorite error:", error);
-                res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({});
-            }
+            console.error("Add favorite error:", error);
+            res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({});
         }
 });
 

--- a/backend/src/routes/favoriteRoutes.ts
+++ b/backend/src/routes/favoriteRoutes.ts
@@ -1,25 +1,77 @@
 import {authenticateToken, AuthRequest} from "../middleware/authMiddleware";
 import {StatusCodes} from "http-status-codes";
-import { body, validationResult } from 'express-validator';
+import { body, param } from 'express-validator';
 import {Router} from "express";
 import {validateRequest} from "../middleware/validationMiddleware";
+import { Unit } from "../db/unit";
+import { FavoriteService } from "../services/favoriteService";
 
 const router = Router();
 
 router.get('/', authenticateToken, (req: AuthRequest, res) => {
-    res.sendStatus(StatusCodes.CONFLICT);
-})
+    const unit = new Unit(true);
+    try {
+        const favoriteService = new FavoriteService(unit);
+        const userId = parseInt(req.user!.userId as unknown as string, 10);
+        const favorites = favoriteService.getFavorites(userId);
+        res.status(StatusCodes.OK).json(favorites);
+    } catch (error) {
+        console.error("Get favorites error:", error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({});
+    } finally {
+        unit.complete();
+    }
+});
 
 router.post('/',
     authenticateToken,
-    body('recipeId').notEmpty().withMessage('friendId is required'),
+    body('recipeId').notEmpty().withMessage('recipeId is required').isInt().withMessage('recipeId must be an integer').toInt(),
     validateRequest,
     (req: AuthRequest, res) => {
-    res.sendStatus(StatusCodes.CONFLICT);
-})
+        const unit = new Unit(false);
+        try {
+            const favoriteService = new FavoriteService(unit);
+            const userId = parseInt(req.user!.userId as unknown as string, 10);
+            const { recipeId } = req.body;
+            
+            const newFavorite = favoriteService.addFavorite(userId, recipeId);
+            unit.complete(true);
+            res.status(StatusCodes.CREATED).json(newFavorite);
+        } catch (error: any) {
+            unit.complete(false);
+            if (error.message && error.message.includes('FOREIGN KEY constraint failed')) {
+                res.status(StatusCodes.BAD_REQUEST).json({ message: "Recipe not found in local database." });
+            } else {
+                console.error("Add favorite error:", error);
+                res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({});
+            }
+        }
+});
 
-router.delete('/:recipeId', (req: AuthRequest, res) => {
-    res.sendStatus(StatusCodes.CONFLICT);
-})
+router.delete('/:recipeId', 
+    authenticateToken, 
+    param('recipeId').isInt().withMessage('recipeId must be an integer').toInt(),
+    validateRequest,
+    (req: AuthRequest, res) => {
+    const unit = new Unit(false);
+    try {
+        const favoriteService = new FavoriteService(unit);
+        const userId = parseInt(req.user!.userId as unknown as string, 10);
+        const recipeId = parseInt(req.params.recipeId as string, 10);
+        
+        const success = favoriteService.removeFavorite(userId, recipeId);
+        if (success) {
+            unit.complete(true);
+            res.status(StatusCodes.OK).json({});
+        } else {
+            unit.complete(false);
+            res.status(StatusCodes.NOT_FOUND).json({});
+        }
+    } catch (error) {
+        unit.complete(false);
+        console.error("Remove favorite error:", error);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({});
+    }
+});
 
 export default router;

--- a/backend/src/services/favoriteService.ts
+++ b/backend/src/services/favoriteService.ts
@@ -1,0 +1,23 @@
+import { Unit } from "../db/unit";
+import { FavoriteRepository } from "../repository/favoriteRepository";
+import { FavoriteFood } from "../types";
+
+export class FavoriteService {
+    private favoriteRepository: FavoriteRepository;
+
+    constructor(unit: Unit) {
+        this.favoriteRepository = new FavoriteRepository(unit);
+    }
+
+    public getFavorites(userId: number): FavoriteFood[] {
+        return this.favoriteRepository.findByUserId(userId);
+    }
+
+    public addFavorite(userId: number, recipeId: number): FavoriteFood {
+        return this.favoriteRepository.create(userId, recipeId);
+    }
+
+    public removeFavorite(userId: number, recipeId: number): boolean {
+        return this.favoriteRepository.delete(userId, recipeId);
+    }
+}


### PR DESCRIPTION
## Items to Review

- Should we really fetch the recipe when its missing from the local cache and someone favorites it? Not doing this would dissatisfy the foreign key constraint in the database, meaning we would need to let the request fail

## Summary
This pull request introduces a complete implementation for managing users' favorite recipes, including the repository, service, and route layers. The changes enable users to add, retrieve, and remove favorite recipes, with proper validation and error handling.

**Favorite recipes feature implementation:**

* Added a new `FavoriteRepository` class to handle database interactions for favorite recipes, including methods to find, create, and delete favorites.
* Introduced a `FavoriteService` class to encapsulate business logic for managing favorite recipes, delegating data access to the repository.

**API route enhancements for favorites:**

* Updated `favoriteRoutes.ts` to implement GET, POST, and DELETE endpoints for managing favorites, including input validation, authentication, and error handling. The routes now use the new service and repository layers for their operations.
* Ensured that adding a favorite recipe checks for the existence of the recipe before insertion to maintain referential integrity.