### PR TITLE
More profile routes (couldn't be bothered to test)

### DIFF
--- a/backend/src/public/swagger.yaml
+++ b/backend/src/public/swagger.yaml
@@ -115,16 +115,14 @@ components:
           type: string
           pattern: '^\d{6}$'
           description: 6-digit verification code
-    UpdateProfileRequest:
+    UpdatePictureRequest:
       type: object
       required:
-        - name
+        - profilePicture
       properties:
-        name:
-          type: string
         profilePicture:
           type: string
-          format: uri
+          description: Base64 encoded image string
     UpdateNameRequest:
       type: object
       required:
@@ -146,6 +144,7 @@ components:
           type: string
           format: password
           minLength: 8
+          description: Must contain at least one uppercase letter, one lowercase letter, one number and one special character
     AddFriendRequest:
       type: object
       required:
@@ -362,18 +361,19 @@ paths:
           description: Missing or invalid authentication
         '500':
           description: Internal server error
-    put:
-      summary: Update current user profile
+  /users/me/picture:
+    patch:
+      summary: Update current user's profile picture
       tags: [User]
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateProfileRequest'
+              $ref: '#/components/schemas/UpdatePictureRequest'
       responses:
         '200':
-          description: Profile updated
+          description: Profile picture updated successfully
           content:
             application/json:
               schema:

--- a/backend/src/public/swagger.yaml
+++ b/backend/src/public/swagger.yaml
@@ -125,6 +125,27 @@ components:
         profilePicture:
           type: string
           format: uri
+    UpdateNameRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          maxLength: 50
+    UpdatePasswordRequest:
+      type: object
+      required:
+        - currentPassword
+        - newPassword
+      properties:
+        currentPassword:
+          type: string
+          format: password
+        newPassword:
+          type: string
+          format: password
+          minLength: 8
     AddFriendRequest:
       type: object
       required:
@@ -363,6 +384,58 @@ paths:
             application/json:
               schema:
                  $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Missing or invalid authentication
+        '404':
+          description: User not found
+        '500':
+          description: Internal server error
+  /users/me/name:
+    patch:
+      summary: Update current user's name
+      tags: [User]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateNameRequest'
+      responses:
+        '200':
+          description: Name updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                 $ref: '#/components/schemas/ValidationErrorResponse'
+        '401':
+          description: Missing or invalid authentication
+        '404':
+          description: User not found
+        '409':
+          description: Name already taken
+        '500':
+          description: Internal server error
+  /users/me/password:
+    patch:
+      summary: Update current user's password
+      tags: [User]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePasswordRequest'
+      responses:
+        '204':
+          description: Password updated successfully
+        '400':
+          description: Invalid request body or incorrect current password
         '401':
           description: Missing or invalid authentication
         '404':

--- a/backend/src/repository/userRepository.ts
+++ b/backend/src/repository/userRepository.ts
@@ -75,4 +75,18 @@ export class UserRepository {
             throw new Error("User not found to update verification status");
         }
     }
+
+    public updateName(id: number, name: string): User {
+        const stmt = this.unit.prepare<User>("UPDATE User SET name = :name WHERE id = :id RETURNING *", { id, name });
+        const user = stmt.get();
+        if (!user) {
+            throw new Error("User not found to update name");
+        }
+        return user;
+    }
+
+    public updatePassword(id: number, passwordHash: string): void {
+        const stmt = this.unit.prepare("UPDATE User SET password = :passwordHash WHERE id = :id", { id, passwordHash });
+        stmt.run();
+    }
 }

--- a/backend/src/routes/profileRoutes.ts
+++ b/backend/src/routes/profileRoutes.ts
@@ -32,7 +32,7 @@ router.get('/', authenticateToken, async (req: AuthRequest, res) => {
     }
 });
 
-router.put('/',
+router.patch('/picture',
     authenticateToken,
     body('profilePicture').notEmpty().withMessage('Profile picture is required').isBase64().withMessage('Profile picture has to be base64'),
     validateRequest,
@@ -93,7 +93,8 @@ router.patch('/name',
 router.patch('/password',
     authenticateToken,
     body('currentPassword').notEmpty().withMessage('Current password is required'),
-    body('newPassword').isLength({ min: 8 }).withMessage('New password must be at least 8 characters long'),
+    body('newPassword').isLength({ min: 8 }).withMessage('New password must be at least 8 characters long')
+        .isStrongPassword().withMessage("Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number and one special character"),
     validateRequest,
     async (req: AuthRequest, res) => {
         const unit = new Unit(false);

--- a/backend/src/routes/profileRoutes.ts
+++ b/backend/src/routes/profileRoutes.ts
@@ -2,9 +2,10 @@ import {authenticateToken, AuthRequest} from "../middleware/authMiddleware";
 import {StatusCodes} from "http-status-codes";
 import { body } from 'express-validator';
 import {Router} from "express";
-import {validateRequest} from "../middleware/validationMiddleware";
+import { validateRequest } from "../middleware/validationMiddleware";
 import { UserRepository } from "../repository/userRepository";
 import { Unit } from "../db/unit";
+import { comparePassword, hashPassword } from "../utils";
 
 const router = Router();
 
@@ -53,6 +54,74 @@ router.put('/',
                 return res.sendStatus(StatusCodes.NOT_FOUND);
             }
             console.error("Update profile error:", error);
+            return res.sendStatus(StatusCodes.INTERNAL_SERVER_ERROR);
+        }
+});
+
+router.patch('/name',
+    authenticateToken,
+    body('name').notEmpty().withMessage('Name is required').isLength({ max: 50 }).withMessage('Name must be at most 50 characters'),
+    validateRequest,
+    async (req: AuthRequest, res) => {
+        const unit = new Unit(false);
+        try {
+            const userId = parseInt(req.user!.userId as unknown as string, 10);
+            const userRepo = new UserRepository(unit);
+
+            const existingUser = userRepo.findByName(req.body.name);
+            if (existingUser) {
+                unit.complete(false);
+                return res.sendStatus(StatusCodes.CONFLICT);
+            }
+
+            const updatedUser = userRepo.updateName(userId, req.body.name);
+            unit.complete(true);
+            
+            const { password: _, ...userDto } = updatedUser;
+            return res.status(StatusCodes.OK).json(userDto);
+        }
+        catch (error: any) {
+            unit.complete(false);
+            if (error.message.includes("User not found")) {
+                return res.sendStatus(StatusCodes.NOT_FOUND);
+            }
+            console.error("Update name error:", error);
+            return res.sendStatus(StatusCodes.INTERNAL_SERVER_ERROR);
+        }
+});
+
+router.patch('/password',
+    authenticateToken,
+    body('currentPassword').notEmpty().withMessage('Current password is required'),
+    body('newPassword').isLength({ min: 8 }).withMessage('New password must be at least 8 characters long'),
+    validateRequest,
+    async (req: AuthRequest, res) => {
+        const unit = new Unit(false);
+        try {
+            const userId = parseInt(req.user!.userId as unknown as string, 10);
+            const userRepo = new UserRepository(unit);
+
+            const user = userRepo.findById(userId);
+            if (!user) {
+                unit.complete(false);
+                return res.sendStatus(StatusCodes.NOT_FOUND);
+            }
+
+            const isValidPassword = await comparePassword(req.body.currentPassword, user.password);
+            if (!isValidPassword) {
+                unit.complete(false);
+                return res.sendStatus(StatusCodes.BAD_REQUEST);
+            }
+
+            const newPasswordHash = await hashPassword(req.body.newPassword);
+            userRepo.updatePassword(userId, newPasswordHash);
+            unit.complete(true);
+            
+            return res.sendStatus(StatusCodes.NO_CONTENT);
+        }
+        catch (error: any) {
+            unit.complete(false);
+            console.error("Update password error:", error);
             return res.sendStatus(StatusCodes.INTERNAL_SERVER_ERROR);
         }
 });


### PR DESCRIPTION
This pull request introduces new endpoints and refactors the user profile update logic to provide more granular control over profile updates. Instead of a single endpoint for updating all profile fields, there are now separate endpoints for updating the user's profile picture, name, and password. The changes also add validation and error handling for these operations.

**API Schema and Endpoint Changes**

* Split the previous `UpdateProfileRequest` schema into three new schemas: `UpdatePictureRequest` (for profile picture), `UpdateNameRequest` (for name), and `UpdatePasswordRequest` (for password), each with appropriate validation constraints.
* Added new PATCH endpoints in `swagger.yaml` for `/users/me/picture`, `/users/me/name`, and `/users/me/password`, each with detailed request/response documentation and error handling. [[1]](diffhunk://#diff-6a05c044c165b8bcb18f9adf419a17ce8444f28d6883a1deb652dae3e41f7bd0L344-R376) [[2]](diffhunk://#diff-6a05c044c165b8bcb18f9adf419a17ce8444f28d6883a1deb652dae3e41f7bd0R393-R444)

**Backend Route and Repository Updates**

* Refactored `profileRoutes.ts` to implement the new PATCH endpoints: `/picture`, `/name`, and `/password`, each with specific validation, business logic, and error handling. [[1]](diffhunk://#diff-6437d3f37d2da14b902d9630d3aa265bc957a32213048c5aff46a7d2d6bc7f4aL34-R35) [[2]](diffhunk://#diff-6437d3f37d2da14b902d9630d3aa265bc957a32213048c5aff46a7d2d6bc7f4aR61-R129)
* Updated the `UserRepository` with `updateName` and `updatePassword` methods to support the new endpoints.

**Utilities and Validation**

* Added imports for password hashing and comparison utilities to support secure password updates.

These changes improve the security, clarity, and maintainability of user profile updates by separating concerns and enforcing stricter validation.