### PR TITLE
Filters and Calendar fixes

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import { seedFilters } from "./db/seedFilters";
 import { parseDurationToMilliseconds } from "./utils";
 import rateLimit from "express-rate-limit";
 import { apiQuotaLimiter } from "./middleware/apiQuotaLimiter";
+import { initializeFilterCache } from "./utils/filterCache";
 
 const PORT = process.env.PORT || "3000";
 const allowedOrigins = (process.env.CORS_ORIGIN ?? "")
@@ -36,6 +37,7 @@ const unit = new Unit(true);
 unit.complete(null);
 
 await seedFilters();
+await initializeFilterCache();
 await cleanup();
 
 app.use(cors({ origin: allowedOrigins, credentials: true }));

--- a/backend/src/repository/calendarRepository.ts
+++ b/backend/src/repository/calendarRepository.ts
@@ -15,7 +15,9 @@ export class CalendarRepository {
 
     public findByUserIdAndDateRange(userId: number, fromDate: Date, toDate: Date): CalendarEntry[] {
         const fromISO = fromDate.toISOString().split('T')[0];
-        const toISO = toDate.toISOString().split('T')[0];
+        const nextDay = new Date(toDate);
+        nextDay.setDate(nextDay.getDate() + 1);
+        const toISO = nextDay.toISOString().split('T')[0];
         const stmt = this.unit.prepare<CalendarEntry>(
             "SELECT * FROM CalenderEntry WHERE userId = :userId AND date BETWEEN :fromDate AND :toDate ORDER BY date ASC",
             { userId, fromDate: fromISO, toDate: toISO }

--- a/backend/src/repository/filterRepository.ts
+++ b/backend/src/repository/filterRepository.ts
@@ -1,61 +1,11 @@
-import { Unit } from "../db/unit";
-
-interface FilterOption {
-    pretty_name: string;
-    type: string;
-    min?: number;
-    max?: number;
-}
-
-interface FilterGroup {
-    icon: string;
-    options: Record<string, FilterOption>;
-}
+import { getFilterCache } from "../utils/filterCache";
 
 interface FiltersResponse {
-    filters: Record<string, FilterGroup>;
+    filters: Record<string, Record<string, any>>;
 }
 
 export class FilterRepository {
     getFiltersStructured(): FiltersResponse {
-        const unit = new Unit(true);
-        try {
-            const groups = unit.prepare<{ id: number; name: string; icon: string }>(
-                "SELECT id, name, icon FROM FilterGroup ORDER BY id"
-            ).all();
-
-            const filters = unit.prepare<{ id: number; groupId: number; name: string; prettyName: string; type: string; min: number | null; max: number | null }>(
-                "SELECT id, groupId, name, prettyName, type, min, max FROM Filter ORDER BY groupId, id"
-            ).all();
-
-            const result: FiltersResponse = { filters: {} };
-
-            for (const group of groups) {
-                const groupFilters = filters.filter(f => f.groupId === group.id);
-                const options: Record<string, FilterOption> = {};
-
-                for (const filter of groupFilters) {
-                    const option: FilterOption = {
-                        pretty_name: filter.prettyName,
-                        type: filter.type,
-                    };
-                    if (filter.min !== null) option.min = filter.min;
-                    if (filter.max !== null) option.max = filter.max;
-
-                    options[filter.name] = option;
-                }
-
-                result.filters[group.name] = {
-                    icon: group.icon,
-                    options,
-                };
-            }
-
-            unit.complete();
-            return result;
-        } catch (error) {
-            unit.complete();
-            throw error;
-        }
+        return getFilterCache();
     }
 }

--- a/backend/src/utils/filterCache.ts
+++ b/backend/src/utils/filterCache.ts
@@ -1,0 +1,67 @@
+import { Unit } from "../db/unit";
+
+interface FilterOption {
+    pretty_name: string;
+    type: string;
+    min?: number;
+    max?: number;
+}
+
+interface FilterGroup {
+    icon: string;
+    options: Record<string, FilterOption>;
+}
+
+interface FiltersResponse {
+    filters: Record<string, FilterGroup>;
+}
+
+let cachedFilters: FiltersResponse | null = null;
+
+export async function initializeFilterCache(): Promise<void> {
+    const unit = new Unit(true);
+    try {
+        const groups = unit.prepare<{ id: number; name: string; icon: string }>(
+            "SELECT id, name, icon FROM FilterGroup ORDER BY id"
+        ).all();
+
+        const filters = unit.prepare<{ id: number; groupId: number; name: string; prettyName: string; type: string; min: number | null; max: number | null }>(
+            "SELECT id, groupId, name, prettyName, type, min, max FROM Filter ORDER BY groupId, id"
+        ).all();
+
+        const result: FiltersResponse = { filters: {} };
+
+        for (const group of groups) {
+            const groupFilters = filters.filter(f => f.groupId === group.id);
+            const options: Record<string, FilterOption> = {};
+
+            for (const filter of groupFilters) {
+                const option: FilterOption = {
+                    pretty_name: filter.prettyName,
+                    type: filter.type,
+                };
+                if (filter.min !== null) option.min = filter.min;
+                if (filter.max !== null) option.max = filter.max;
+
+                options[filter.name] = option;
+            }
+
+            result.filters[group.name] = {
+                icon: group.icon,
+                options,
+            };
+        }
+
+        cachedFilters = result;
+        console.log("Filter cache initialized");
+    } finally {
+        unit.complete();
+    }
+}
+
+export function getFilterCache(): FiltersResponse {
+    if (!cachedFilters) {
+        throw new Error("Filter cache not initialized");
+    }
+    return cachedFilters;
+}


### PR DESCRIPTION
closes #86 
closes #87

This pull request introduces a filter cache mechanism to improve performance and reliability when serving filter data. The main changes include moving filter data loading to application startup, restructuring how filters are accessed, and updating the calendar repository's date range logic.

**Filter cache implementation and usage:**

* Added a new `filterCache` utility (`backend/src/utils/filterCache.ts`) that loads filter data from the database at startup, caches it in memory, and provides `initializeFilterCache` and `getFilterCache` functions for initialization and access. (`[backend/src/utils/filterCache.tsR1-R67](diffhunk://#diff-f63fdf686dbf559fa38ae58d301a9a372e1f2aa622cf3a4d8736ab48aa5d89e2R1-R67)`)
* Updated `app.ts` to call `initializeFilterCache()` during application startup to ensure the filter cache is populated before handling requests. (`[[1]](diffhunk://#diff-8455472d7e00dd51813de7e63e5b214382a247990f84bf3fbed9fcc3af24ad6fR22)`, `[[2]](diffhunk://#diff-8455472d7e00dd51813de7e63e5b214382a247990f84bf3fbed9fcc3af24ad6fR40)`)
* Refactored `FilterRepository` to use the cached filter data via `getFilterCache()` instead of querying the database on every request, removing redundant code and improving efficiency. (`[backend/src/repository/filterRepository.tsL1-R9](diffhunk://#diff-b70655f345963802e426839ead524e3170a4ff4926738c1d4edd7480e09cb227L1-R9)`)

**Other improvements:**

* Modified the `findByUserIdAndDateRange` method in `CalendarRepository` to include the entire end date by incrementing the `toDate` by one day, ensuring the date range is inclusive. (`[backend/src/repository/calendarRepository.tsL18-R20](diffhunk://#diff-ac45ba61e4f8db386cac8f58eb82bd548aa05d123be7f3f1627068692cf7b547L18-R20)`)