### PR TITLE
Feature/88 calendar populate

### DIFF
--- a/backend/src/repository/localRecipeRepository.ts
+++ b/backend/src/repository/localRecipeRepository.ts
@@ -70,6 +70,27 @@ export class LocalRecipeRepository {
         return this.saveRecipesWithDetails([{ recipe, details }]);
     }
 
+    async findRecipesByIds(ids: number[]): Promise<RecipeWithDetails[]> {
+        if (ids.length === 0) return [];
+        const unit = new Unit(true);
+        const cutoff = new Date(Date.now() - CACHE_TTL_MS).toISOString();
+        const placeholders = ids.map((_, i) => `:id${i}`).join(', ');
+        const params: Record<string, any> = { cutoff };
+        ids.forEach((id, i) => { params[`id${i}`] = id; });
+        const stmt = unit.prepare<RecipeWithDetails>(`
+            SELECT r.id, r.name, r.image,
+                   d.readyInMinutes, d.servings, d.stepCount, d.ingredientCount, d.pricePerServing,
+                   d.effortScore, d.rating, d.aggregateLikes,
+                   d.vegetarian, d.vegan, d.glutenFree, d.dairyFree
+            FROM Recipe r
+            INNER JOIN RecipeDetails d ON d.recipeId = r.id
+            WHERE r.id IN (${placeholders}) AND r.updatedAt > :cutoff
+        `, params);
+        const recipes = stmt.all();
+        unit.complete();
+        return recipes;
+    }
+
     async findRecipeById(id: number): Promise<RecipeWithDetails | undefined> {
         const unit = new Unit(true);
         const cutoff = new Date(Date.now() - CACHE_TTL_MS).toISOString();

--- a/backend/src/repository/remoteRecipeRepository.ts
+++ b/backend/src/repository/remoteRecipeRepository.ts
@@ -40,6 +40,27 @@ export class RemoteRecipeRepository {
         }));
     }
 
+    async getRecipesByIds(ids: number[], userIp?: string): Promise<RecipeWithRawDetails[]> {
+        if (ids.length === 0) return [];
+        const url = `${this.API_URL}/informationBulk?ids=${ids.join(',')}&apiKey=${this.API_KEY}`;
+        const response = await fetch(url);
+
+        if (userIp) {
+            const pointsUsed = parseInt(response.headers.get("X-API-Quota-Request") || "0", 10);
+            updateQuota(userIp, pointsUsed);
+        }
+
+        if (!response.ok) {
+            throw new Error(`Error fetching bulk recipes: ${response.statusText}`);
+        }
+
+        const results: any[] = await response.json();
+        return results.map((r: any) => ({
+            recipe: { id: r.id, name: r.title, image: r.image },
+            details: this.extractDetails(r),
+        }));
+    }
+
     async getRecipeById(id: number, userIp?: string): Promise<RecipeWithRawDetails | undefined> {
         const url = `${this.API_URL}/${id}/information?apiKey=${this.API_KEY}`;
         const response = await fetch(url);

--- a/backend/src/routes/calendarRoutes.ts
+++ b/backend/src/routes/calendarRoutes.ts
@@ -14,13 +14,15 @@ router.get('/',
     authenticateToken,
     query('from').optional().isISO8601().withMessage('from must be a valid ISO8601 date'),
     query('to').optional().isISO8601().withMessage('to must be a valid ISO8601 date'),
+    query('populate').optional().isBoolean().withMessage('populate must be a boolean'),
     validateRequest,
-    (req: AuthRequest, res) => {
+    async (req: AuthRequest, res) => {
     const unit = new Unit(true);
     try {
         const calendarService = new CalendarService(unit);
         const from = req.query.from as string | undefined;
         const to = req.query.to as string | undefined;
+        const populate = req.query.populate === 'true';
 
         let entries;
         if (from && to) {
@@ -30,7 +32,15 @@ router.get('/',
         } else {
             entries = calendarService.getCalendarEntries(req.user!.userId);
         }
+
+        if (populate) {
+            const populated = await calendarService.populateWithRecipes(entries, req.ip);
+            return res.json(populated);
+        }
+
         res.json(entries);
+    } catch (error) {
+        return ErrorResponse.internalServerError(res, "Failed to retrieve calendar entries");
     } finally {
         unit.complete();
     }

--- a/backend/src/services/calendarService.ts
+++ b/backend/src/services/calendarService.ts
@@ -1,6 +1,7 @@
 import { Unit } from "../db/unit";
 import { CalendarRepository } from "../repository/calendarRepository";
-import { CalendarEntry } from "../types";
+import { CalendarEntry, CalendarEntryWithRecipe } from "../types";
+import { RecipeService } from "./recipeService";
 
 export class CalendarService {
     private calendarRepository: CalendarRepository;
@@ -15,6 +16,16 @@ export class CalendarService {
 
     public getCalendarEntriesByDateRange(userId: number, fromDate: Date, toDate: Date): CalendarEntry[] {
         return this.calendarRepository.findByUserIdAndDateRange(userId, fromDate, toDate);
+    }
+
+    public async populateWithRecipes(entries: CalendarEntry[], userIp?: string): Promise<CalendarEntryWithRecipe[]> {
+        const recipeIds = [...new Set(entries.map(e => e.recipeId))];
+        const recipeService = new RecipeService();
+        const recipeMap = await recipeService.getRecipesByIds(recipeIds, userIp);
+        return entries.map(entry => ({
+            ...entry,
+            recipe: recipeMap.get(entry.recipeId) ?? null,
+        }));
     }
 
     public getCalendarEntryById(id: number): CalendarEntry | undefined {

--- a/backend/src/services/recipeService.ts
+++ b/backend/src/services/recipeService.ts
@@ -54,6 +54,27 @@ export class RecipeService {
         return toRecipePreview({ id: remote.recipe.id, name: remote.recipe.name, image: remote.recipe.image, ...remote.details });
     }
 
+    async getRecipesByIds(ids: number[], userIp?: string): Promise<Map<number, RecipePreviewResponse>> {
+        const result = new Map<number, RecipePreviewResponse>();
+        if (ids.length === 0) return result;
+
+        const cached = await this.localRepo.findRecipesByIds(ids);
+        for (const r of cached) {
+            result.set(r.id, toRecipePreview(r));
+        }
+
+        const uncachedIds = ids.filter(id => !result.has(id));
+        if (uncachedIds.length > 0) {
+            const remote = await this.remoteRepo.getRecipesByIds(uncachedIds, userIp);
+            this.localRepo.saveRecipesWithDetails(remote).catch(console.error);
+            for (const { recipe, details } of remote) {
+                result.set(recipe.id, toRecipePreview({ id: recipe.id, name: recipe.name, image: recipe.image, ...details }));
+            }
+        }
+
+        return result;
+    }
+
     async removeExpiredRecipes(): Promise<void> {
         await this.localRepo.removeExpiredRecipes();
     }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -82,3 +82,7 @@ export interface FavoriteFood {
     userId: number;
     recipeId: number;
 }
+
+export interface CalendarEntryWithRecipe extends CalendarEntry {
+    recipe: RecipePreviewResponse | null;
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows calendar entries to be optionally populated with detailed recipe information in a single API call. It implements efficient bulk fetching and caching of recipe data, and updates the calendar API and service layers to support this enhancement.

Key changes include:

**API and Route Enhancements**
* Added a `populate` query parameter to the calendar route (`calendarRoutes.ts`), allowing clients to request calendar entries with embedded recipe details. The endpoint now supports async handlers and improved error handling. [[1]](diffhunk://#diff-f037a387c4ba41c17272869b5f0ae0d4230abc1289a233c870b7dc470598bd05R17-R25) [[2]](diffhunk://#diff-f037a387c4ba41c17272869b5f0ae0d4230abc1289a233c870b7dc470598bd05R35-R43)

**Service Layer Updates**
* Implemented `populateWithRecipes` in `CalendarService` to efficiently enrich calendar entries with recipe details using the new bulk recipe fetching logic.
* Added a `getRecipesByIds` method to `RecipeService` to fetch multiple recipes at once, using local cache and falling back to remote API as needed, with results mapped by recipe ID.

**Repository Layer Improvements**
* Added `findRecipesByIds` to `LocalRecipeRepository` for efficient local bulk recipe lookup.
* Added `getRecipesByIds` to `RemoteRecipeRepository` to fetch multiple recipes in a single remote API call, including quota tracking.

**Type Definitions**
* Introduced a new `CalendarEntryWithRecipe` type to represent calendar entries with optional embedded recipe previews.