### PR TITLE
Favorites population and pagination

### DIFF
--- a/backend/example.env
+++ b/backend/example.env
@@ -4,6 +4,8 @@ JWT_EXPIRY="1h"
 SPOONACULAR_API_KEY="key"
 CACHE_TTL_MS="24h" // format: 1s, 1m, 1h, 1d
 CORS_ORIGIN="http://localhost:8080" // ',' to separate multiple origins, e.g. "http://localhost:8080,http://example.com"
+RATE_LIMIT_WINDOW_MS=900000 // time window in milliseconds (900000 = 15 minutes)
+RATE_LIMIT_MAX_REQUESTS=200 // max requests per IP per window
 #EMAIL_HOST="smtp.example.com"
 #EMAIL_PORT=587
 #EMAIL_SECURE="false"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -29,6 +29,8 @@ const allowedOrigins = (process.env.CORS_ORIGIN ?? "")
 export const CACHE_TTL_MS =
     parseDurationToMilliseconds(process.env.CACHE_TTL_MS
         ,24 * 60 * 60 * 1000);
+const RATE_LIMIT_WINDOW_MS = parseInt(process.env.RATE_LIMIT_WINDOW_MS || "900000", 10); // 15 minutes
+const RATE_LIMIT_MAX_REQUESTS = parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || "200", 10);
 
 const app = express();
 
@@ -44,11 +46,11 @@ app.use(cors({ origin: allowedOrigins, credentials: true }));
 app.use(cookieParser());
 app.use(express.json());
 app.use(rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    limit: 200, // Limit each IP to 200 requests per time window
-    standardHeaders: 'draft-8', // draft-6: `RateLimit-*` headers; draft-7 & draft-8: combined `RateLimit` header
-    legacyHeaders: false, // Disable the `X-RateLimit-*` headers.
-    ipv6Subnet: 56, // Set to 60 or 64 to be less aggressive, or 52 or 48 to be more aggressive
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    limit: RATE_LIMIT_MAX_REQUESTS,
+    standardHeaders: 'draft-8',
+    legacyHeaders: false,
+    ipv6Subnet: 56,
     handler: (req, res) => {
         res.status(429).json({ message: "Too many requests, please try again later." });
     }

--- a/backend/src/public/swagger.yaml
+++ b/backend/src/public/swagger.yaml
@@ -29,29 +29,41 @@ components:
           format: uri
           nullable: true
         isVerified:
-          type: boolean
+           type: boolean
     Friend:
-      type: object
-      properties:
-        userId:
-          type: integer
-        friendId:
-          type: integer
+       type: object
+       properties:
+         userId:
+           type: integer
+         friendId:
+           type: integer
     FavoriteFood:
-      type: object
-      properties:
-        userId:
-          type: integer
-        recipeId:
-          type: integer
+       type: object
+       properties:
+         userId:
+           type: integer
+         recipeId:
+           type: integer
+    FavoriteFoodWithRecipe:
+       type: object
+       properties:
+         userId:
+           type: integer
+         recipeId:
+           type: integer
+         recipe:
+           allOf:
+             - $ref: '#/components/schemas/RecipePreview'
+             - type: object
+               nullable: true
     User:
-      type: object
-      required:
-        - id
-        - name
-        - email
-        - profilePicture
-      properties:
+       type: object
+       required:
+         - id
+         - name
+         - email
+         - profilePicture
+       properties:
         id:
           type: integer
         name:
@@ -794,50 +806,76 @@ paths:
         '500':
           description: Internal server error
   /users/me/favorites:
-    get:
-      summary: Get favorite recipes
-      tags: [Favorites]
-      responses:
-        '200':
-           description: Favorite recipes
+     get:
+       summary: Get favorite recipes
+       tags: [Favorites]
+       parameters:
+         - in: query
+           name: populate
+           schema:
+             type: boolean
+           description: 'When true, includes full recipe details. When false (default), returns only IDs'
+         - in: query
+           name: offset
+           schema:
+             type: integer
+             minimum: 0
+           description: Number of results to skip (pagination). Applied before population for performance.
+         - in: query
+           name: limit
+           schema:
+             type: integer
+             minimum: 1
+           description: Maximum number of results to return. Unlimited if omitted.
+       responses:
+         '200':
+            description: Favorite recipes (with or without full recipe details based on populate flag)
+            content:
+             application/json:
+               schema:
+                 type: array
+                 items:
+                   oneOf:
+                     - $ref: '#/components/schemas/FavoriteFood'
+                     - $ref: '#/components/schemas/FavoriteFoodWithRecipe'
+         '400':
+           description: Invalid query parameters
            content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/FavoriteFood'
-        '401':
-          description: Missing or invalid authentication
-        '500':
-          description: Internal server error
-    post:
-      summary: Add recipe to favorites
-      tags: [Favorites]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AddFavoriteRequest'
-      responses:
-        '201':
-          description: Added to favorites
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FavoriteFood'
-        '400':
-          description: Invalid request body
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ValidationErrorResponse'
-        '401':
-          description: Missing or invalid authentication
-        '404':
-          description: Recipe not found
-        '500':
-          description: Internal server error
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/ValidationErrorResponse'
+         '401':
+           description: Missing or invalid authentication
+         '500':
+           description: Internal server error
+     post:
+       summary: Add recipe to favorites
+       tags: [Favorites]
+       requestBody:
+         required: true
+         content:
+           application/json:
+             schema:
+               $ref: '#/components/schemas/AddFavoriteRequest'
+       responses:
+         '201':
+           description: Added to favorites
+           content:
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/FavoriteFood'
+         '400':
+           description: Invalid request body
+           content:
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/ValidationErrorResponse'
+         '401':
+           description: Missing or invalid authentication
+         '404':
+           description: Recipe not found
+         '500':
+           description: Internal server error
   /users/me/favorites/{recipeId}:
     delete:
       summary: Remove recipe from favorites

--- a/backend/src/repository/favoriteRepository.ts
+++ b/backend/src/repository/favoriteRepository.ts
@@ -8,11 +8,20 @@ export class FavoriteRepository {
         this.unit = unit;
     }
 
-    public findByUserId(userId: number): FavoriteFood[] {
-        const stmt = this.unit.prepare<FavoriteFood>(
-            "SELECT * FROM FavoriteFood WHERE userId = :userId", 
-            { userId }
-        );
+    public findByUserId(userId: number, offset?: number, limit?: number): FavoriteFood[] {
+        let query = "SELECT * FROM FavoriteFood WHERE userId = :userId";
+        const params: any = { userId };
+        
+        if (offset !== undefined && offset > 0) {
+            query += " LIMIT :limit OFFSET :offset";
+            params.offset = offset;
+            params.limit = limit ?? -1;
+        } else if (limit !== undefined && limit > 0) {
+            query += " LIMIT :limit";
+            params.limit = limit;
+        }
+        
+        const stmt = this.unit.prepare<FavoriteFood>(query, params);
         return stmt.all();
     }
 

--- a/backend/src/routes/favoriteRoutes.ts
+++ b/backend/src/routes/favoriteRoutes.ts
@@ -1,7 +1,7 @@
 import { ErrorResponse } from "../utils/errorResponse";
 import {authenticateToken, AuthRequest} from "../middleware/authMiddleware";
 import {StatusCodes} from "http-status-codes";
-import { body, param } from 'express-validator';
+import { body, param, query } from 'express-validator';
 import {Router} from "express";
 import {validateRequest} from "../middleware/validationMiddleware";
 import { Unit } from "../db/unit";
@@ -11,12 +11,28 @@ import { RecipeService } from "../services/recipeService";
 
 const router = Router();
 
-router.get('/', authenticateToken, (req: AuthRequest, res) => {
+router.get('/',
+    authenticateToken,
+    query('populate').optional().isBoolean(),
+    query('offset').optional().isInt({ min: 0 }).toInt(),
+    query('limit').optional().isInt({ min: 1 }).toInt(),
+    validateRequest,
+    async (req: AuthRequest, res) => {
     const unit = new Unit(true);
     try {
+        const populate = req.query.populate === 'true';
+        const offset = req.query.offset as number | undefined;
+        const limit = req.query.limit as number | undefined;
+        
         const favoriteService = new FavoriteService(unit);
         const userId = parseInt(req.user!.userId as unknown as string, 10);
-        const favorites = favoriteService.getFavorites(userId);
+        const favorites = favoriteService.getFavorites(userId, offset, limit);
+        
+        if (populate) {
+            const populated = await favoriteService.populateWithRecipes(favorites, req.ip);
+            return res.status(StatusCodes.OK).json(populated);
+        }
+        
         res.status(StatusCodes.OK).json(favorites);
     } catch (error) {
         console.error("Get favorites error:", error);

--- a/backend/src/services/favoriteService.ts
+++ b/backend/src/services/favoriteService.ts
@@ -1,6 +1,11 @@
 import { Unit } from "../db/unit";
 import { FavoriteRepository } from "../repository/favoriteRepository";
 import { FavoriteFood } from "../types";
+import { RecipeService } from "./recipeService";
+
+interface FavoriteFoodWithRecipe extends FavoriteFood {
+    recipe?: any;
+}
 
 export class FavoriteService {
     private favoriteRepository: FavoriteRepository;
@@ -9,8 +14,20 @@ export class FavoriteService {
         this.favoriteRepository = new FavoriteRepository(unit);
     }
 
-    public getFavorites(userId: number): FavoriteFood[] {
-        return this.favoriteRepository.findByUserId(userId);
+    public getFavorites(userId: number, offset?: number, limit?: number): FavoriteFood[] {
+        return this.favoriteRepository.findByUserId(userId, offset, limit);
+    }
+
+    public async populateWithRecipes(favorites: FavoriteFood[], userIp?: string): Promise<FavoriteFoodWithRecipe[]> {
+        const recipeIds = [...new Set(favorites.map(f => f.recipeId))];
+        
+        const recipeService = new RecipeService();
+        const recipeMap = await recipeService.getRecipesByIds(recipeIds, userIp);
+        
+        return favorites.map(favorite => ({
+            ...favorite,
+            recipe: recipeMap.get(favorite.recipeId) ?? null,
+        }));
     }
 
     public addFavorite(userId: number, recipeId: number): FavoriteFood {


### PR DESCRIPTION
closes #101 

This pull request adds support for paginated and optionally populated favorite recipes in the backend API. It introduces new query parameters to the favorites endpoint, updates the repository and service layers to handle pagination, and allows clients to request full recipe details for each favorite. Additionally, rate limiting configuration is now environment-based for easier adjustment.

**API enhancements:**

* The `/favorites` endpoint now accepts `populate`, `offset`, and `limit` query parameters, allowing clients to paginate results and request full recipe details (`populate=true`). The OpenAPI spec (`swagger.yaml`) is updated to document these changes, including the new response schema and validation for query parameters.
* The backend validates the new query parameters and returns a `400` error for invalid input. [[1]](diffhunk://#diff-e2c358be8114a29d7427aea18a2d1c96dcbf314423199a2df51b52da105cce5cL14-R35) [[2]](diffhunk://#diff-6a05c044c165b8bcb18f9adf419a17ce8444f28d6883a1deb652dae3e41f7bd0R812-R846)

**Repository and service updates:**

* `FavoriteRepository` and `FavoriteService` now support fetching favorites with optional pagination (`offset` and `limit`), and the service provides a method to populate each favorite with its associated recipe details. [[1]](diffhunk://#diff-56e8c94c61f696af439cd1709d58c8920097c23220fe70a7ccb2973f82ed30a0L11-R24) [[2]](diffhunk://#diff-8bc51cbe583553a3895b543f7030d4dd50400300f2cb450067955b6ade096dfaL12-R30)

**Rate limiting configuration:**

* Rate limiting settings (`windowMs` and `max requests`) are now configurable via environment variables, making it easier to adjust limits without code changes. [[1]](diffhunk://#diff-c22b52f20001ac613348108480af25c4b1fc9f4e606db18175ee2d93684cf360R7-R8) [[2]](diffhunk://#diff-8455472d7e00dd51813de7e63e5b214382a247990f84bf3fbed9fcc3af24ad6fR32-R33) [[3]](diffhunk://#diff-8455472d7e00dd51813de7e63e5b214382a247990f84bf3fbed9fcc3af24ad6fL47-R53)

**OpenAPI/Swagger schema updates:**

* Added the `FavoriteFoodWithRecipe` schema and updated response types to reflect the new `populate` option. [[1]](diffhunk://#diff-6a05c044c165b8bcb18f9adf419a17ce8444f28d6883a1deb652dae3e41f7bd0R47-R58) [[2]](diffhunk://#diff-6a05c044c165b8bcb18f9adf419a17ce8444f28d6883a1deb652dae3e41f7bd0R812-R846)