### PR TITLE
fix(theme): guard matchMedia during SSR

### DIFF
--- a/frontend/app/composables/useTheme.ts
+++ b/frontend/app/composables/useTheme.ts
@@ -9,6 +9,7 @@ export function useTheme() {
 
   function resolve(c: ThemeChoice): "light" | "dark" {
     if (c !== "system") return c;
+    if (!import.meta.client) return "dark";
     return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
   }
 


### PR DESCRIPTION
resolve() accessed window.matchMedia on the server during prerender, crashing the build. Return "dark" when not on client.